### PR TITLE
Add Makefile with build, test, and packaging targets

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -40,20 +40,20 @@ Each task follows this workflow:
 - ~~Create initial commit~~
 
 ### Create Makefile
-- [ ] `make help` - parse `## target - description` comments and display all targets
-- [ ] `make setup-build-env` - install Rust (locked version), musl target, cargo-deb, musl-tools
-- [ ] `make build` - cargo build
-- [ ] `make release` - cargo build --release --target x86_64-unknown-linux-musl
-- [ ] `make test` - cargo test
-- [ ] `make fmt` - cargo fmt
-- [ ] `make lint` - cargo clippy
-- [ ] `make check` - fmt + lint + test
-- [ ] `make install` - install binary to system
-- [ ] `make clean` - cargo clean + remove build artifacts
-- [ ] `make deb` - build debian package
-- [ ] `make install-deb` - install the .deb package
-- [ ] `make uninstall-deb` - remove the installed .deb package
-- [ ] Every target must have a `## target - description` comment
+- [TAKEN] `make help` - parse `## target - description` comments and display all targets
+- [TAKEN] `make setup-build-env` - install Rust (locked version), musl target, cargo-deb, musl-tools
+- [TAKEN] `make build` - cargo build
+- [TAKEN] `make release` - cargo build --release --target x86_64-unknown-linux-musl
+- [TAKEN] `make test` - cargo test
+- [TAKEN] `make fmt` - cargo fmt
+- [TAKEN] `make lint` - cargo clippy
+- [TAKEN] `make check` - fmt + lint + test
+- [TAKEN] `make install` - install binary to system
+- [TAKEN] `make clean` - cargo clean + remove build artifacts
+- [TAKEN] `make deb` - build debian package
+- [TAKEN] `make install-deb` - install the .deb package
+- [TAKEN] `make uninstall-deb` - remove the installed .deb package
+- [TAKEN] Every target must have a `## target - description` comment
 
 ### Set Up GitHub Repository
 - ~~Create repo on github.com/yanctab~~

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,80 @@
+# shclap Makefile
+
+BINARY_NAME := shclap
+CARGO := cargo
+INSTALL_PATH := /usr/local/bin
+MUSL_TARGET := x86_64-unknown-linux-musl
+RUST_VERSION := 1.81.0
+
+.PHONY: help setup-build-env build release test fmt lint check install uninstall clean deb install-deb uninstall-deb
+
+.DEFAULT_GOAL := help
+
+## help - Display this help message
+help:
+	@echo "Available targets:"
+	@grep -E '^## [a-zA-Z]' $(MAKEFILE_LIST) | sed 's/## //' | awk -F ' - ' '{printf "  %-18s %s\n", $$1, $$2}'
+
+## setup-build-env - Install Rust, musl target, cargo-deb, and musl-tools
+setup-build-env:
+	@echo "Installing Rust $(RUST_VERSION)..."
+	rustup install $(RUST_VERSION)
+	rustup default $(RUST_VERSION)
+	@echo "Adding musl target..."
+	rustup target add $(MUSL_TARGET)
+	@echo "Installing musl-tools..."
+	sudo apt-get update && sudo apt-get install -y musl-tools
+	@echo "Installing cargo-deb..."
+	$(CARGO) install cargo-deb
+	@echo "Build environment setup complete."
+
+## build - Build the project in debug mode
+build:
+	$(CARGO) build
+
+## release - Build static release binary with musl
+release:
+	$(CARGO) build --release --target $(MUSL_TARGET)
+
+## test - Run all tests
+test:
+	$(CARGO) test
+
+## fmt - Format code with rustfmt
+fmt:
+	$(CARGO) fmt
+
+## lint - Run clippy linter
+lint:
+	$(CARGO) clippy -- -D warnings
+
+## check - Run fmt, lint, and test
+check: fmt lint test
+
+## install - Install binary to system ($(INSTALL_PATH))
+install: release
+	sudo cp target/$(MUSL_TARGET)/release/$(BINARY_NAME) $(INSTALL_PATH)/$(BINARY_NAME)
+	@echo "Installed $(BINARY_NAME) to $(INSTALL_PATH)"
+
+## uninstall - Remove binary from system
+uninstall:
+	sudo rm -f $(INSTALL_PATH)/$(BINARY_NAME)
+	@echo "Uninstalled $(BINARY_NAME) from $(INSTALL_PATH)"
+
+## clean - Clean build artifacts
+clean:
+	$(CARGO) clean
+	rm -rf target/
+	rm -f *.deb
+
+## deb - Build Debian package
+deb: release
+	$(CARGO) deb --target $(MUSL_TARGET)
+
+## install-deb - Install the Debian package
+install-deb:
+	sudo dpkg -i target/$(MUSL_TARGET)/debian/*.deb
+
+## uninstall-deb - Remove the installed Debian package
+uninstall-deb:
+	sudo dpkg -r $(BINARY_NAME)


### PR DESCRIPTION
- Add help target that parses ## comments for self-documentation
- Add setup-build-env for Rust, musl, and cargo-deb installation
- Add build, release (musl static), test, fmt, lint, check targets
- Add install/uninstall for system-wide binary installation
- Add deb, install-deb, uninstall-deb for Debian packaging
- Add clean target for build artifacts