### PR TITLE
Refactor CLI to use subcommands (Phase 3)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,59 +1,78 @@
 //! shclap - Clap-style argument parsing for shell scripts.
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use shclap::{generate_help, generate_output, generate_version, parse_args, Config};
 
 /// Clap-style argument parsing for shell scripts.
 #[derive(Parser, Debug)]
-#[command(name = "shclap", version, about)]
+#[command(name = "shclap", version, about, disable_help_subcommand = true)]
 struct Cli {
-    /// JSON configuration for the target script
-    #[arg(long)]
-    config: String,
+    #[command(subcommand)]
+    command: Commands,
+}
 
-    /// Environment variable prefix (overrides config prefix)
-    #[arg(long)]
-    prefix: Option<String>,
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Parse script arguments and output environment variables
+    Parse {
+        /// JSON configuration for the target script
+        #[arg(long)]
+        config: String,
 
-    /// Arguments to parse for the target script
-    #[arg(last = true)]
-    script_args: Vec<String>,
+        /// Environment variable prefix (overrides config)
+        #[arg(long)]
+        prefix: Option<String>,
+
+        /// Arguments to parse for the target script
+        #[arg(last = true)]
+        args: Vec<String>,
+    },
+
+    /// Print help text for the target script
+    Help {
+        /// JSON configuration for the target script
+        #[arg(long)]
+        config: String,
+    },
+
+    /// Print version of the target script
+    Version {
+        /// JSON configuration for the target script
+        #[arg(long)]
+        config: String,
+    },
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // Parse and validate config
-    let config = Config::from_json(&cli.config).context("failed to parse config JSON")?;
-    config.validate().context("invalid config")?;
+    match cli.command {
+        Commands::Parse {
+            config,
+            prefix,
+            args,
+        } => {
+            let cfg = Config::from_json(&config).context("failed to parse config JSON")?;
+            cfg.validate().context("invalid config")?;
 
-    // Determine effective prefix: CLI > config > default
-    let prefix = cli
-        .prefix
-        .as_deref()
-        .unwrap_or_else(|| config.effective_prefix());
+            let effective_prefix = prefix.as_deref().unwrap_or_else(|| cfg.effective_prefix());
 
-    // Check for --help or -h in script args
-    if cli.script_args.iter().any(|a| a == "--help" || a == "-h") {
-        print!("{}", generate_help(&config));
-        return Ok(());
+            let parsed = parse_args(&cfg, &args).context("failed to parse arguments")?;
+            let path = generate_output(&parsed, effective_prefix)
+                .context("failed to generate output file")?;
+
+            println!("{}", path.display());
+        }
+        Commands::Help { config } => {
+            let cfg = Config::from_json(&config).context("failed to parse config JSON")?;
+            print!("{}", generate_help(&cfg));
+        }
+        Commands::Version { config } => {
+            let cfg = Config::from_json(&config).context("failed to parse config JSON")?;
+            print!("{}", generate_version(&cfg));
+        }
     }
-
-    // Check for --version in script args
-    if cli.script_args.iter().any(|a| a == "--version") {
-        print!("{}", generate_version(&config));
-        return Ok(());
-    }
-
-    // Parse the script arguments
-    let parsed = parse_args(&config, &cli.script_args).context("failed to parse arguments")?;
-
-    // Generate output file
-    let output_path = generate_output(&parsed, prefix).context("failed to generate output file")?;
-
-    // Print the path so the shell script can source it
-    println!("{}", output_path.display());
 
     Ok(())
 }
@@ -64,18 +83,29 @@ mod tests {
     use clap::CommandFactory;
 
     #[test]
-    fn test_cli_parses_config() {
-        let cli = Cli::try_parse_from(["shclap", "--config", r#"{"name":"test"}"#, "--"]).unwrap();
+    fn test_parse_subcommand_parses_config() {
+        let cli = Cli::try_parse_from(["shclap", "parse", "--config", r#"{"name":"test"}"#, "--"])
+            .unwrap();
 
-        assert_eq!(cli.config, r#"{"name":"test"}"#);
-        assert!(cli.prefix.is_none());
-        assert!(cli.script_args.is_empty());
+        match cli.command {
+            Commands::Parse {
+                config,
+                prefix,
+                args,
+            } => {
+                assert_eq!(config, r#"{"name":"test"}"#);
+                assert!(prefix.is_none());
+                assert!(args.is_empty());
+            }
+            _ => panic!("Expected Parse command"),
+        }
     }
 
     #[test]
-    fn test_cli_parses_prefix() {
+    fn test_parse_subcommand_parses_prefix() {
         let cli = Cli::try_parse_from([
             "shclap",
+            "parse",
             "--config",
             r#"{"name":"test"}"#,
             "--prefix",
@@ -84,13 +114,19 @@ mod tests {
         ])
         .unwrap();
 
-        assert_eq!(cli.prefix, Some("MYAPP_".to_string()));
+        match cli.command {
+            Commands::Parse { prefix, .. } => {
+                assert_eq!(prefix, Some("MYAPP_".to_string()));
+            }
+            _ => panic!("Expected Parse command"),
+        }
     }
 
     #[test]
-    fn test_cli_parses_script_args() {
+    fn test_parse_subcommand_parses_args() {
         let cli = Cli::try_parse_from([
             "shclap",
+            "parse",
             "--config",
             r#"{"name":"test"}"#,
             "--",
@@ -101,29 +137,73 @@ mod tests {
         ])
         .unwrap();
 
-        assert_eq!(
-            cli.script_args,
-            vec!["-v", "--output", "file.txt", "input.txt"]
-        );
+        match cli.command {
+            Commands::Parse { args, .. } => {
+                assert_eq!(args, vec!["-v", "--output", "file.txt", "input.txt"]);
+            }
+            _ => panic!("Expected Parse command"),
+        }
     }
 
     #[test]
-    fn test_cli_requires_config() {
-        let result = Cli::try_parse_from(["shclap", "--"]);
+    fn test_parse_subcommand_requires_config() {
+        let result = Cli::try_parse_from(["shclap", "parse", "--"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_help_subcommand() {
+        let cli = Cli::try_parse_from([
+            "shclap",
+            "help",
+            "--config",
+            r#"{"name":"test","description":"A test"}"#,
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Help { config } => {
+                assert_eq!(config, r#"{"name":"test","description":"A test"}"#);
+            }
+            _ => panic!("Expected Help command"),
+        }
+    }
+
+    #[test]
+    fn test_version_subcommand() {
+        let cli = Cli::try_parse_from([
+            "shclap",
+            "version",
+            "--config",
+            r#"{"name":"test","version":"1.0.0"}"#,
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Version { config } => {
+                assert_eq!(config, r#"{"name":"test","version":"1.0.0"}"#);
+            }
+            _ => panic!("Expected Version command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_requires_subcommand() {
+        let result = Cli::try_parse_from(["shclap"]);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_cli_help() {
-        // Just verify the command can generate help without panicking
+        // Verify the command can generate help without panicking
         Cli::command().debug_assert();
     }
 
     #[test]
     fn test_prefix_priority_cli_overrides_config() {
-        // When CLI prefix is set, it should override config prefix
         let cli = Cli::try_parse_from([
             "shclap",
+            "parse",
             "--config",
             r#"{"name":"test","prefix":"CONFIG_"}"#,
             "--prefix",
@@ -132,48 +212,61 @@ mod tests {
         ])
         .unwrap();
 
-        let config = Config::from_json(&cli.config).unwrap();
-
-        // CLI prefix takes priority
-        let effective = cli
-            .prefix
-            .as_deref()
-            .unwrap_or_else(|| config.effective_prefix());
-
-        assert_eq!(effective, "CLI_");
+        match cli.command {
+            Commands::Parse {
+                config,
+                prefix,
+                args: _,
+            } => {
+                let cfg = Config::from_json(&config).unwrap();
+                let effective = prefix.as_deref().unwrap_or_else(|| cfg.effective_prefix());
+                assert_eq!(effective, "CLI_");
+            }
+            _ => panic!("Expected Parse command"),
+        }
     }
 
     #[test]
     fn test_prefix_priority_config_when_no_cli() {
         let cli = Cli::try_parse_from([
             "shclap",
+            "parse",
             "--config",
             r#"{"name":"test","prefix":"CONFIG_"}"#,
             "--",
         ])
         .unwrap();
 
-        let config = Config::from_json(&cli.config).unwrap();
-
-        let effective = cli
-            .prefix
-            .as_deref()
-            .unwrap_or_else(|| config.effective_prefix());
-
-        assert_eq!(effective, "CONFIG_");
+        match cli.command {
+            Commands::Parse {
+                config,
+                prefix,
+                args: _,
+            } => {
+                let cfg = Config::from_json(&config).unwrap();
+                let effective = prefix.as_deref().unwrap_or_else(|| cfg.effective_prefix());
+                assert_eq!(effective, "CONFIG_");
+            }
+            _ => panic!("Expected Parse command"),
+        }
     }
 
     #[test]
     fn test_prefix_priority_default_when_neither_set() {
-        let cli = Cli::try_parse_from(["shclap", "--config", r#"{"name":"test"}"#, "--"]).unwrap();
+        let cli = Cli::try_parse_from(["shclap", "parse", "--config", r#"{"name":"test"}"#, "--"])
+            .unwrap();
 
-        let config = Config::from_json(&cli.config).unwrap();
-
-        let effective = cli
-            .prefix
-            .as_deref()
-            .unwrap_or_else(|| config.effective_prefix());
-
-        assert_eq!(effective, "SHCLAP_");
+        match cli.command {
+            Commands::Parse {
+                config,
+                prefix,
+                args: _,
+            } => {
+                let cfg = Config::from_json(&config).unwrap();
+                let effective = prefix.as_deref().unwrap_or_else(|| cfg.effective_prefix());
+                assert_eq!(effective, "SHCLAP_");
+            }
+            _ => panic!("Expected Parse command"),
+        }
     }
 }


### PR DESCRIPTION
Replace flat CLI structure with explicit subcommands:
- parse: Parse script arguments and output environment variables
- help: Print help text for the target script
- version: Print version of the target script

This gives shell scripts explicit control over help/version handling instead of detecting --help/--version by scanning script_args.