### PR TITLE
Refactor parser to use dynamic Clap command building

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["cli", "shell", "argument-parsing", "bash"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-clap = { version = "=4.4.18", features = ["derive"] }
+clap = { version = "=4.4.18", features = ["derive", "string"] }
 serde = { version = "=1.0.196", features = ["derive"] }
 serde_json = "=1.0.113"
 tempfile = "=3.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub mod output;
 pub mod parser;
 
 pub use config::{ArgConfig, ArgType, Config, ConfigError, CURRENT_SCHEMA_VERSION};
-pub use help::{generate_help, generate_usage, generate_version};
+pub use help::{generate_help, generate_version};
 pub use output::{
     generate_error_output, generate_error_string, generate_help_output,
     generate_help_output_string, generate_output, generate_output_string, generate_version_output,

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
             let cfg = match Config::from_json(&config) {
                 Ok(c) => c,
                 Err(e) => {
-                    return output_error(&e.to_string());
+                    return output_error(&format!("failed to parse JSON config: {}", e));
                 }
             };
 
@@ -73,25 +73,23 @@ fn main() -> Result<()> {
 
             // Handle parse result
             match parse_args(&cfg, &args) {
-                Ok(ParseOutcome::Success(parsed)) => {
+                ParseOutcome::Success(parsed) => {
                     let path = generate_output(&parsed, effective_prefix)
                         .context("failed to generate output file")?;
                     println!("{}", path.display());
                 }
-                Ok(ParseOutcome::Help) => {
-                    let help_text = generate_help(&cfg);
+                ParseOutcome::Help(help_text) => {
                     let path = generate_help_output(&help_text)
                         .context("failed to generate help output file")?;
                     println!("{}", path.display());
                 }
-                Ok(ParseOutcome::Version) => {
-                    let version_text = generate_version(&cfg);
+                ParseOutcome::Version(version_text) => {
                     let path = generate_version_output(&version_text)
                         .context("failed to generate version output file")?;
                     println!("{}", path.display());
                 }
-                Err(e) => {
-                    return output_error(&e.to_string());
+                ParseOutcome::Error(error_msg) => {
+                    return output_error(&error_msg);
                 }
             }
         }

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -267,7 +267,7 @@ fi
 run_test
 OUTPUT=$("$SHCLAP" parse --config '{"name":"myapp","args":[{"name":"verbose","short":"v","type":"flag"}]}' -- -v --help)
 HELP_OUTPUT=$(bash -c "source '$OUTPUT'" 2>&1) || true
-if echo "$HELP_OUTPUT" | grep -q "USAGE"; then
+if echo "$HELP_OUTPUT" | grep -qi "usage"; then
     pass "--help takes precedence over other flags"
 else
     fail "--help precedence" "Should display help even with other flags" "$HELP_OUTPUT"


### PR DESCRIPTION
Replace custom argument parsing logic (~250 lines) with Clap's built-in parsing by dynamically constructing Command/Arg from JSON config at runtime.

Changes:
- parser.rs: Build clap::Command from Config, map ArgConfig to clap::Arg
- help.rs: Use Clap's render_help() instead of custom help generation
- main.rs: Handle ParseOutcome variants for help/version/error
- lib.rs: Update exports (add ParseOutcome, remove generate_usage)
- Cargo.toml: Add clap "string" feature for owned String support
- tests/integration.sh: Fix case-insensitive grep for Clap's "Usage:" format

Benefits:
- Leverages Clap's well-tested parsing (combined flags, attached values, etc.)
- Consistent help/error messages matching Clap conventions
- Reduced custom code to maintain