### PR TITLE
Add schema_version 2 with env fallback, multiple values, and subcommands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["cli", "shell", "argument-parsing", "bash"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-clap = { version = "=4.4.18", features = ["derive", "string"] }
+clap = { version = "=4.4.18", features = ["derive", "string", "env"] }
 serde = { version = "=1.0.196", features = ["derive"] }
 serde_json = "=1.0.113"
 tempfile = "=3.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,14 @@ pub mod help;
 pub mod output;
 pub mod parser;
 
-pub use config::{ArgConfig, ArgType, Config, ConfigError, CURRENT_SCHEMA_VERSION};
+pub use config::{
+    ArgConfig, ArgType, Config, ConfigError, SubcommandConfig, MAX_SCHEMA_VERSION,
+    MIN_SCHEMA_VERSION,
+};
 pub use help::{generate_help, generate_version};
 pub use output::{
     generate_error_output, generate_error_string, generate_help_output,
-    generate_help_output_string, generate_output, generate_output_string, generate_version_output,
-    generate_version_output_string,
+    generate_help_output_string, generate_output, generate_output_string,
+    generate_output_string_legacy, generate_version_output, generate_version_output_string,
 };
-pub use parser::{parse_args, ParseError, ParseOutcome, ParseResult};
+pub use parser::{parse_args, ParseError, ParseOutcome, ParseResult, ParseSuccess, ParsedValue};

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,9 +73,13 @@ fn main() -> Result<()> {
 
             // Handle parse result
             match parse_args(&cfg, &args) {
-                ParseOutcome::Success(parsed) => {
-                    let path = generate_output(&parsed, effective_prefix)
-                        .context("failed to generate output file")?;
+                ParseOutcome::Success(result) => {
+                    let path = generate_output(
+                        &result.values,
+                        effective_prefix,
+                        result.subcommand.as_deref(),
+                    )
+                    .context("failed to generate output file")?;
                     println!("{}", path.display());
                 }
                 ParseOutcome::Help(help_text) => {


### PR DESCRIPTION
New features for schema_version 2:
- Environment variable fallback (env field)
- Multiple/variadic arguments (multiple, num_args, delimiter fields)
- Subcommand support with nested arguments
- Bash array output for multiple values
- SHCLAP_SUBCOMMAND output variable

Backward compatibility:
- Schema v1 configs work unchanged
- V2 fields in v1 configs produce validation errors
- All existing tests continue to pass

Files changed:
- config.rs: SubcommandConfig struct, new ArgConfig fields, validation
- parser.rs: ParseSuccess/ParsedValue types, subcommand handling
- help.rs: Mirror parser changes for help generation
- output.rs: Bash array syntax, subcommand output
- lib.rs: Export new types
- main.rs: Wire new types together
- Cargo.toml: Add clap 'env' feature
- integration.sh: 16 new tests for v2 features