### PR TITLE
Consolidate schema documentation into unified schema.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ make setup-build-env && make release && make install
 ## Documentation
 
 - [Configuration Reference](docs/configuration.md)
-- [Schema Version 2 Features](docs/schema-v2.md)
+- [Schema Reference](docs/schema.md)
 - [Examples](docs/examples.md)
 - [CLI Reference](docs/cli-reference.md)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -161,5 +161,5 @@ source $(shclap parse --config "$CONFIG" --prefix="APP_" -- "$@")
 ## See Also
 
 - [Configuration Reference](configuration.md) - Full JSON schema reference
-- [Schema Version 2 Features](schema-v2.md) - Extended features
+- [Schema Reference](schema.md) - Schema versioning and v2 features
 - [Examples](examples.md) - Complete working examples

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,6 +95,6 @@ For example, with default prefix `SHCLAP_`:
 
 ## See Also
 
-- [Schema Version 2 Features](schema-v2.md) - Extended features like env fallback, multiple values, subcommands
+- [Schema Reference](schema.md) - Schema versioning and v2 features
 - [Examples](examples.md) - Complete working examples
 - [CLI Reference](cli-reference.md) - Command-line options

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -329,5 +329,5 @@ Usage:
 ## See Also
 
 - [Configuration Reference](configuration.md) - Full JSON schema reference
-- [Schema Version 2 Features](schema-v2.md) - Extended features
+- [Schema Reference](schema.md) - Schema versioning and v2 features
 - [CLI Reference](cli-reference.md) - Command-line options


### PR DESCRIPTION
- Create docs/schema.md covering both v1 and v2 schemas
- Add "Choosing a Schema Version" guidance
- Include migration instructions from v1 to v2
- Update all documentation links to reference schema.md
- Remove docs/schema-v2.md (content merged into schema.md)