### PR TITLE
Improve README to better explain shclap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # shclap
 
-Clap-style argument parsing for shell scripts.
+Declarative argument parsing for shell scripts. Define your CLI in JSON, get parsed arguments as environment variables.
+
+## Why shclap?
+
+Writing argument parsing in shell scripts is tedious and error-prone. Manual `getopts` or `getopt` code is verbose, hard to read, and doesn't give you nice error messages or auto-generated help.
+
+**shclap** lets you:
+- **Declare your CLI in JSON** instead of writing imperative parsing code
+- **Get auto-generated `--help` and `--version`** for free
+- **Validate arguments** with clear error messages
+- **Access parsed values as environment variables** with a customizable prefix
 
 ## Quick Start
 
@@ -16,6 +26,42 @@ source $(shclap parse --config "$CONFIG" -- "$@")
 echo "Hello, $SHCLAP_NAME!"
 ```
 
+## How It Works
+
+1. **Define** your arguments in JSON (inline or in a file)
+2. **Parse** by running `shclap parse` with your config and script arguments
+3. **Source** the output file to get environment variables
+
+All parsed arguments become environment variables with a prefix (default: `SHCLAP_`). For example:
+- `--output file.txt` → `$SHCLAP_OUTPUT="file.txt"`
+- `--verbose` → `$SHCLAP_VERBOSE="true"`
+- positional `input` → `$SHCLAP_INPUT="value"`
+
+The prefix is customizable via `--prefix` or in your config.
+
+## Features
+
+### Schema Versions
+
+shclap supports two schema versions:
+
+**v1** (default) — Simple scripts:
+- Flags (`-v`, `--verbose`)
+- Options (`-o file`, `--output=file`)
+- Positional arguments
+
+**v2** — Advanced use cases:
+- Environment variable fallback for options
+- Multiple values as bash arrays
+- Subcommands
+
+### Environment Variable Output
+
+All parsed arguments are exported as environment variables:
+- Default prefix: `SHCLAP_`
+- Customize with `--prefix` flag or `prefix` in config
+- Names are uppercased: `--my-option` → `$SHCLAP_MY_OPTION`
+
 ## Installation
 
 ### From GitHub Releases
@@ -30,20 +76,11 @@ Download from [Releases](https://github.com/yanctab/shclap/releases):
 make setup-build-env && make release && make install
 ```
 
-## Features
-
-- **Flags**: `-v`, `--verbose`
-- **Options**: `-o file`, `--output=file`
-- **Positional arguments**: `input.txt`
-- **Environment variable fallback** (v2)
-- **Multiple values as bash arrays** (v2)
-- **Subcommands** (v2)
-
 ## Documentation
 
 - [Configuration Reference](docs/configuration.md)
 - [Schema Reference](docs/schema.md)
-- [Examples](docs/examples.md)
+- [Examples](docs/examples.md) — More complex use cases
 - [CLI Reference](docs/cli-reference.md)
 
 ## Development


### PR DESCRIPTION
- Add "Why shclap?" section explaining benefits over manual parsing
- Add "How It Works" section with 3-step flow
- Document environment variable output and prefix system
- Explain schema versions (v1 vs v2)
- Keep original Quick Start example
- Highlight examples link in documentation