### PR TITLE
Add value_type validation for arguments (schema v2)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -233,7 +233,7 @@ Each task follows this workflow:
 - ~~Extend the cli-reference.md with this new flag.~~
 - ~~Short and long should be optional if no short is specified then only long is accepted if long is not specified then the name should be used as the long.~~
 - ~~It should be possible to specify what values are supported so like value1, value2, value3 if the flag is not set to any of these three values then it should fail listing what values are supported.~~ (Implemented as `choices` field in schema v2)
-- Do we need to be able to define if a value should be string, bool or int?
+- ~~Do we need to be able to define if a value should be string, bool or int?~~ (Implemented as `value_type` field in schema v2)
 
 ### Documentation
 - Clarify "Environment variable fallback for options" in the schematic v2 I don't understand it.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,7 @@ Each argument in the `args` array can have the following fields:
 | `num_args` | string | No | Number of values per occurrence (v2 only) |
 | `delimiter` | string | No | Split single value by delimiter (v2 only) |
 | `choices` | array | No | Allowed values for this argument (v2 only) |
+| `value_type` | string | No | Value type validation: "string" (default), "int", "bool" (v2 only) |
 
 ### Long Option Fallback
 
@@ -102,6 +103,15 @@ Both configurations accept `--verbose` and `--output`.
       "choices": ["json", "yaml", "toml"],
       "default": "json",
       "help": "Output format"
+    },
+    {
+      "name": "count",
+      "short": "n",
+      "long": "count",
+      "type": "option",
+      "value_type": "int",
+      "default": "10",
+      "help": "Number of items to process"
     },
     {
       "name": "config",

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -18,6 +18,7 @@ See [Configuration Reference](configuration.md) for the complete field reference
 | Simple scripts with basic flags and options | v1 (default) |
 | Need environment variable fallback | v2 |
 | Need multiple values (arrays) | v2 |
+| Need value type validation (int, bool) | v2 |
 | Need subcommands like `git init`, `git commit` | v2 |
 
 ## Schema Version 1 (Default)
@@ -53,6 +54,7 @@ Version 1 does not support:
 - Environment variable fallback (`env` field)
 - Multiple values (`multiple` field)
 - Value choices/enums (`choices` field)
+- Value type validation (`value_type` field)
 - Subcommands (`subcommands` field)
 
 ## Schema Version 2
@@ -155,6 +157,38 @@ Choices work with both options and positional arguments:
 - The choices array must have at least one value
 - Duplicate values in choices are not allowed
 - Valid values are shown in help output
+
+### Value Type Validation
+
+Validate that argument values match expected types using the `value_type` field. Invalid values will be rejected with clear error messages.
+
+```json
+{"name": "count", "long": "count", "type": "option", "value_type": "int"}
+{"name": "enabled", "long": "enabled", "type": "option", "value_type": "bool"}
+{"name": "port", "type": "positional", "value_type": "int"}
+```
+
+**Supported types:**
+
+| Type | Description | Valid Examples | Invalid Examples |
+|------|-------------|----------------|------------------|
+| `string` | Any string value (default) | Any value | N/A |
+| `int` | Signed 64-bit integer | `42`, `-10`, `0` | `abc`, `3.14` |
+| `bool` | Strict boolean | `true`, `false` | `yes`, `no`, `1`, `0` |
+
+```bash
+$ myapp --count 42        # OK
+$ myapp --count abc       # Error: invalid digit found in string
+$ myapp --count -10       # OK (negatives allowed for int)
+$ myapp --enabled true    # OK
+$ myapp --enabled yes     # Error: invalid value 'yes'
+```
+
+**Notes:**
+- `value_type` cannot be used with flags (flags are inherently boolean by presence/absence)
+- If not specified, defaults to `string` (no validation)
+- If both `choices` and `value_type` are specified, `choices` takes precedence (it's more restrictive)
+- `bool` uses strict `true`/`false` only—not `yes`/`no` or `1`/`0`
 
 ### Subcommands
 


### PR DESCRIPTION
Add a value_type field to ArgConfig that validates argument values match expected types. Supported types are string (default), int (signed 64-bit), and bool (strict true/false only). Invalid values are rejected with clear error messages. This field cannot be used with flags since they are inherently boolean by presence/absence. If both choices and value_type are specified, choices takes precedence.