### PR TITLE
Add Double variant to ValueType enum and config validation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1282,6 +1282,22 @@ mod tests {
     }
 
     #[test]
+    fn test_error_value_type_double_in_v1_config() {
+        let json = r#"{
+            "schema_version": 1,
+            "name": "test",
+            "args": [
+                {"name": "ratio", "long": "ratio", "type": "option", "value_type": "double"}
+            ]
+        }"#;
+        let config = Config::from_json(json).unwrap();
+        let result = config.validate();
+        assert!(
+            matches!(result, Err(ConfigError::FieldRequiresV2(field, _)) if field == "value_type")
+        );
+    }
+
+    #[test]
     fn test_default_value_type_is_string() {
         let json = r#"{
             "schema_version": 2,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1298,6 +1298,26 @@ mod tests {
     }
 
     #[test]
+    fn test_uses_v2_features_with_double_value_type() {
+        let arg = ArgConfig {
+            name: "ratio".to_string(),
+            short: None,
+            long: Some("ratio".to_string()),
+            arg_type: ArgType::Option,
+            required: false,
+            default: None,
+            help: None,
+            env: None,
+            multiple: false,
+            num_args: None,
+            delimiter: None,
+            choices: None,
+            value_type: ValueType::Double,
+        };
+        assert!(arg.uses_v2_features());
+    }
+
+    #[test]
     fn test_default_value_type_is_string() {
         let json = r#"{
             "schema_version": 2,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1239,6 +1239,32 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_accepts_double_on_option() {
+        let json = r#"{
+            "schema_version": 2,
+            "name": "test",
+            "args": [
+                {"name": "ratio", "long": "ratio", "type": "option", "value_type": "double"}
+            ]
+        }"#;
+        let config = Config::from_json(json).unwrap();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_accepts_double_on_positional() {
+        let json = r#"{
+            "schema_version": 2,
+            "name": "test",
+            "args": [
+                {"name": "threshold", "type": "positional", "value_type": "double"}
+            ]
+        }"#;
+        let config = Config::from_json(json).unwrap();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
     fn test_default_value_type_is_string() {
         let json = r#"{
             "schema_version": 2,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1265,6 +1265,23 @@ mod tests {
     }
 
     #[test]
+    fn test_error_value_type_double_on_flag() {
+        let json = r#"{
+            "schema_version": 2,
+            "name": "test",
+            "args": [
+                {"name": "verbose", "short": "v", "type": "flag", "value_type": "double"}
+            ]
+        }"#;
+        let config = Config::from_json(json).unwrap();
+        let result = config.validate();
+        assert!(matches!(
+            result,
+            Err(ConfigError::ValueTypeOnFlag(name)) if name == "verbose"
+        ));
+    }
+
+    #[test]
     fn test_default_value_type_is_string() {
         let json = r#"{
             "schema_version": 2,

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,8 @@ pub enum ValueType {
     Int,
     /// Boolean (strict "true" or "false" only)
     Bool,
+    /// 64-bit floating-point number
+    Double,
 }
 
 /// Environment variable fallback setting (schema_version >= 2).
@@ -1221,6 +1223,19 @@ mod tests {
             result,
             Err(ConfigError::ValueTypeOnFlag(name)) if name == "verbose"
         ));
+    }
+
+    #[test]
+    fn test_from_json_double_value_type_deserialises() {
+        let json = r#"{
+            "schema_version": 2,
+            "name": "test",
+            "args": [
+                {"name": "ratio", "long": "ratio", "type": "option", "value_type": "double"}
+            ]
+        }"#;
+        let config = Config::from_json(json).unwrap();
+        assert_eq!(config.args[0].value_type, ValueType::Double);
     }
 
     #[test]

--- a/src/help.rs
+++ b/src/help.rs
@@ -163,6 +163,9 @@ fn build_arg(
             ValueType::Bool => {
                 arg = arg.value_parser(clap::builder::PossibleValuesParser::new(["true", "false"]));
             }
+            ValueType::Double => {
+                arg = arg.value_parser(clap::value_parser!(f64));
+            }
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -243,6 +243,9 @@ fn build_arg(
             ValueType::Bool => {
                 arg = arg.value_parser(clap::builder::PossibleValuesParser::new(["true", "false"]));
             }
+            ValueType::Double => {
+                arg = arg.value_parser(clap::value_parser!(f64));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `ValueType::Double` variant to the `ValueType` enum in `src/config.rs`, deserialising from `"value_type": "double"` in JSON via the existing `#[serde(rename_all = "lowercase")]` attribute.
- Extends match arms in `src/help.rs` and `src/parser.rs` to handle the new variant using clap's `f64` value parser.
- All existing guard expressions (`!= ValueType::String`) automatically cover `Double`, so validation rules (v1 rejection, flag rejection) required no additional code.

## Acceptance criteria satisfied

**Criterion 1** — `Config::from_json` with `"value_type": "double"` deserialises to `ValueType::Double` without error.
Satisfied by commit `6e1087b`: added `Double` variant to the enum; JSON deserialisation works via serde's `rename_all = "lowercase"`.

**Criterion 2** — `config.validate()` accepts a v2 config with `value_type: double` on an option or positional argument.
Satisfied by commit `1386e21`: the existing `validate_value_type` guard only fires on flags, so option/positional with `Double` passes cleanly.

**Criterion 3** — `config.validate()` returns `ConfigError::ValueTypeOnFlag` when `value_type: double` is combined with `"type": "flag"` on a v2 config.
Satisfied by commit `5e9dc7f`: the existing `arg.value_type != ValueType::String && arg.arg_type == ArgType::Flag` check covers `Double`.

**Criterion 4** — `config.validate()` returns `ConfigError::FieldRequiresV2` for `value_type` when a `double` argument appears in a v1 config.
Satisfied by commit `5670a34`: `validate_no_v2_fields` uses `arg.value_type != ValueType::String`, which covers `Double`.

**Criterion 5** — `ArgConfig::uses_v2_features()` returns `true` for an argument with `value_type: Double`.
Satisfied by commit `e03149f`: `uses_v2_features` uses `self.value_type != ValueType::String`, which covers `Double`.

**Criterion 6** — All existing unit tests continue to pass without modification.
146 unit tests and 50 integration tests pass on every commit throughout the cycle.

## Test plan

- [x] `make unit-test` — 146 tests pass
- [x] `make integration-test` — 50 tests pass
- [x] `make lint` — no warnings

> Please squash-merge this PR per repo convention.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)