### PR TITLE
Wire Double into the help module

### DIFF
--- a/src/help.rs
+++ b/src/help.rs
@@ -527,4 +527,44 @@ mod tests {
             help
         );
     }
+
+    #[test]
+    fn test_generate_help_with_value_type_double() {
+        // Create config with double value_type
+        let double_config = Config {
+            schema_version: 2,
+            name: Some("test".to_string()),
+            description: None,
+            version: None,
+            prefix: None,
+            args: vec![ArgConfig {
+                name: "ratio".to_string(),
+                short: Some('r'),
+                long: Some("ratio".to_string()),
+                arg_type: ArgType::Option,
+                required: false,
+                default: None,
+                help: Some("Calculation ratio".to_string()),
+                env: None,
+                multiple: false,
+                num_args: None,
+                delimiter: None,
+                choices: None,
+                value_type: ValueType::Double,
+            }],
+            subcommands: vec![],
+        };
+
+        let double_help = generate_help(&double_config, get_name(&double_config));
+
+        // Help should be non-empty
+        assert!(!double_help.is_empty(), "Help should not be empty");
+
+        // Help should not contain true/false (no confusion with bool)
+        assert!(
+            !(double_help.contains("true") && double_help.contains("false")),
+            "Help should not show true/false for double value_type: {}",
+            double_help
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Add unit test for `ValueType::Double` in the help module to validate the variant is properly wired. The test verifies that `generate_help` accepts a config with `value_type: double` and produces help output that does not show `true`/`false`, preventing confusion with the `bool` type.

## Acceptance Criteria

- [x] `generate_help` for a config with `value_type: double` on an option produces output that does not show `true`/`false` (no confusion with `bool`)
- [x] All existing help unit tests continue to pass

## Changes

**test(help)**: Add `test_generate_help_with_value_type_double()` 
- Validates that the Double variant is properly handled in the help module
- Asserts the help output is non-empty
- Asserts the help output does not contain `true`/`false`

The implementation (the `ValueType::Double` match arm in `build_arg`) was already present from issue #25/#27, so this commit adds the corresponding test to complete the wiring.

Closes #22

Please squash-merge this PR when approved.

Generated with Claude Code