### PR TITLE
docs(schema): add double row to value type reference table

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -18,7 +18,7 @@ See [Configuration Reference](configuration.md) for the complete field reference
 | Simple scripts with basic flags and options | v1 (default) |
 | Need environment variable fallback | v2 |
 | Need multiple values (arrays) | v2 |
-| Need value type validation (int, bool) | v2 |
+| Need value type validation (int, bool, double) | v2 |
 | Need subcommands like `git init`, `git commit` | v2 |
 
 ## Schema Version 1 (Default)
@@ -203,6 +203,7 @@ Validate that argument values match expected types using the `value_type` field.
 | `string` | Any string value (default) | Any value | N/A |
 | `int` | Signed 64-bit integer | `42`, `-10`, `0` | `abc`, `3.14` |
 | `bool` | Strict boolean | `true`, `false` | `yes`, `no`, `1`, `0` |
+| `double` | IEEE 754 64-bit float | `3.14`, `-2.7`, `0`, `1e10` | `abc`, `3.x` |
 
 ```bash
 $ myapp --count 42        # OK


### PR DESCRIPTION
## Summary

Updated `docs/schema.md` to document the `double` value type that was implemented in issues #25, #26, and #27.

## Acceptance Criteria

- [x] The value type table in `docs/schema.md` contains a `double` row with a description (IEEE 754 64-bit float), valid examples (3.14, -2.7, 0, 1e10), and invalid examples (abc, 3.x) consistent with the existing `int` and `bool` rows.
- [x] The `Choosing a Schema Version` table's row for value type validation is updated to mention `double` (changed from "int, bool" to "int, bool, double").
- [x] No other content in the file is changed.

## Test Plan

- [x] All existing tests pass (56 tests)
- [x] Code formatting checked with `make fmt`
- [x] Linting passes with `make lint`

**Note:** Please squash-merge this PR per repository convention.

Closes #23

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>