### PR TITLE
Docs and README update for double value type

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ shclap supports two schema versions:
 - Environment variable fallback for options
 - Multiple values as bash arrays
 - Subcommands
+- Value type validation (`"string"`, `"int"`, `"bool"`, `"double"`)
 
 ### Environment Variable Output
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -204,6 +204,7 @@ When parsing fails, shclap outputs an error message to stderr (via the sourced t
 | Invalid choice | `shclap: invalid value 'xml' for '--format': valid values: json, yaml, toml` |
 | Invalid type (int) | `shclap: invalid digit found in string` |
 | Invalid type (bool) | `shclap: invalid value 'yes': valid values: true, false` |
+| Invalid type (double) | `shclap: invalid value 'abc' for '--value': invalid float literal` |
 | Invalid JSON config | `shclap: failed to parse JSON config: ...` |
 | Duplicate argument name | `shclap: duplicate argument name: verbose` |
 | Unsupported schema version | `shclap: unsupported schema version 99 (supported: 1-2)` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,7 +34,7 @@ Each argument in the `args` array can have the following fields:
 | `num_args` | string | No | Number of values per occurrence (v2 only) |
 | `delimiter` | string | No | Split single value by delimiter (v2 only) |
 | `choices` | array | No | Allowed values for this argument (v2 only) |
-| `value_type` | string | No | Value type validation: "string" (default), "int", "bool" (v2 only) |
+| `value_type` | string | No | Value type validation: "string" (default), "int", "bool", "double" (v2 only) |
 
 ### Long Option Fallback
 
@@ -215,6 +215,14 @@ Identified by position, not by flags. Order matters.
       "value_type": "int",
       "default": "10",
       "help": "Number of items to process"
+    },
+    {
+      "name": "threshold",
+      "long": "threshold",
+      "type": "option",
+      "value_type": "double",
+      "default": "0.5",
+      "help": "Processing threshold (0.0 to 1.0)"
     },
     {
       "name": "config",

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -356,6 +356,50 @@ Usage:
 ./deploy.sh -e production -V 1.2.3 -f
 ```
 
+## Numeric Option with Double Precision Validation
+
+Processing numeric values with floating-point precision:
+
+```bash
+#!/bin/bash
+CONFIG='{
+  "schema_version": 2,
+  "name": "analyze",
+  "description": "Analyze data with threshold filtering",
+  "args": [
+    {"name": "threshold", "short": "t", "long": "threshold", "type": "option", "value_type": "double", "required": true, "help": "Confidence threshold (0.0-1.0)"},
+    {"name": "input", "type": "positional", "required": true, "help": "Input data file"}
+  ]
+}'
+source $(shclap parse --config "$CONFIG" -- "$@")
+
+echo "Analyzing $SHCLAP_INPUT with threshold: $SHCLAP_THRESHOLD"
+```
+
+Usage with a positive float:
+```bash
+./analyze.sh -t 0.95 data.csv
+# $SHCLAP_THRESHOLD = "0.95"
+```
+
+Usage with a negative float:
+```bash
+./analyze.sh --threshold=-0.5 data.csv
+# $SHCLAP_THRESHOLD = "-0.5"
+```
+
+Usage with scientific notation:
+```bash
+./analyze.sh -t 1e10 data.csv
+# $SHCLAP_THRESHOLD = "10000000000"
+```
+
+Error from non-numeric value:
+```bash
+$ ./analyze.sh -t abc data.csv
+shclap: invalid value 'abc' for '--threshold': invalid float literal
+```
+
 ## See Also
 
 - [Configuration Reference](configuration.md) - Full JSON schema reference


### PR DESCRIPTION
## Summary

This PR updates all user-facing documentation to include the `double` value type across configuration reference, CLI reference, examples, and README.

## Changes by Acceptance Criterion

**Criterion 1:** `docs/configuration.md` `value_type` table cell now reads `"string" (default), "int", "bool", "double"` and the complete JSON example includes a `threshold` argument with `value_type: "double"`.

**Criterion 2:** `docs/cli-reference.md` error-messages table contains a new row for `Invalid type (double)` with an error message containing `"invalid"`, placed immediately after the `Invalid type (bool)` row.

**Criterion 3:** `docs/examples.md` contains a new top-level section "Numeric Option with Double Precision Validation" (before "See Also") with a v2 schema example and usage blocks for a positive float, a negative float, scientific notation (`1e10`), and the error produced by a non-numeric value.

**Criterion 4:** `README.md` v2 feature list contains a fourth bullet: `Value type validation (\`"string"\`, \`"int"\`, \`"bool"\`, \`"double"\`)`.

Closes #32

Please squash-merge when ready.