### PR TITLE
Man page update for double value type

### DIFF
--- a/man/shclap.1
+++ b/man/shclap.1
@@ -208,9 +208,9 @@ Example: ["json", "yaml", "toml"]
 .TP
 .B value_type
 Value type validation. One of: "string" (default, no validation), "int"
-(signed 64-bit integer), or "bool" (strict true/false only). Cannot be used
-with flags. If both choices and value_type are specified, choices takes
-precedence.
+(signed 64-bit integer), "bool" (strict true/false only), or "double"
+(IEEE 754 double-precision float). Cannot be used with flags. If both
+choices and value_type are specified, choices takes precedence.
 .SS "Subcommands (Schema Version 2)"
 .TP
 .B subcommands
@@ -292,6 +292,9 @@ shclap: invalid digit found in string
 .TP
 .B Invalid type (bool)
 shclap: invalid value 'yes': valid values: true, false
+.TP
+.B Invalid type (double)
+shclap: invalid value 'abc' for '--value': ...
 .TP
 .B Invalid JSON config
 shclap: failed to parse JSON config: ...

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -818,6 +818,33 @@ else
 fi
 
 
+section "19. Man Page Documentation"
+
+# Test: Man page contains "double" in value_type description
+run_test
+VALUE_TYPE_SECTION=$(grep -A 5 "^.B value_type" man/shclap.1 | head -6)
+if echo "$VALUE_TYPE_SECTION" | grep -q '"double"' && echo "$VALUE_TYPE_SECTION" | grep -q "IEEE 754 double-precision float"; then
+    pass "Man page includes double in value_type description"
+else
+    fail "Man page value_type description" "Should include 'double' and 'IEEE 754 double-precision float'" "$VALUE_TYPE_SECTION"
+fi
+
+# Test: Man page contains "Invalid type (double)" error entry
+run_test
+if grep -q "Invalid type (double)" man/shclap.1; then
+    # Verify the error is placed after Invalid type (bool)
+    BOOL_LINE=$(grep -n "Invalid type (bool)" man/shclap.1 | cut -d: -f1)
+    DOUBLE_LINE=$(grep -n "Invalid type (double)" man/shclap.1 | cut -d: -f1)
+    if [[ -n "$DOUBLE_LINE" && -n "$BOOL_LINE" && $DOUBLE_LINE -gt $BOOL_LINE ]]; then
+        pass "Man page includes Invalid type (double) error entry after Invalid type (bool)"
+    else
+        fail "Man page error entry order" "Invalid type (double) should come after Invalid type (bool)" "BOOL_LINE=$BOOL_LINE, DOUBLE_LINE=$DOUBLE_LINE"
+    fi
+else
+    fail "Man page error entry" "Should include 'Invalid type (double)'" "$(grep -i 'invalid type' man/shclap.1)"
+fi
+
+
 #
 # Summary
 #


### PR DESCRIPTION
## Summary

Updates the `man/shclap.1` man page to document the `double` value type on equal footing with `int` and `bool`.

## Changes

**Acceptance Criterion 1:** The `.TP .B value_type` description in the man page includes `"double"` and describes it as an IEEE 754 double-precision float.
- Updated line 209-213 to include `"double"` (IEEE 754 double-precision float) in the value_type field description

**Acceptance Criterion 2:** The error block contains a `.TP .B Invalid type (double)` entry with an error message containing `"invalid"`, placed immediately after the `Invalid type (bool)` entry.
- Added `.TP .B Invalid type (double)` error entry after the `Invalid type (bool)` entry in the error messages section

**Tests Added:** Integration tests verify both acceptance criteria
- Test that man page includes double in value_type description
- Test that man page includes Invalid type (double) error entry after Invalid type (bool)

All tests pass successfully (62/62).

**Please squash and merge this PR.**

Closes #33