### PR TITLE
Source comment fix in config.rs for double value type

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -182,7 +182,7 @@ pub struct ArgConfig {
     #[serde(default)]
     pub choices: Option<Vec<String>>,
     /// Value type for validation (schema_version >= 2)
-    /// Options: "string" (default), "int", "bool"
+    /// Options: "string" (default), "int", "bool", "double"
     #[serde(default)]
     pub value_type: ValueType,
 }


### PR DESCRIPTION
## Summary

Fixed the doc comment on the `value_type` field of `ArgConfig` in `src/config.rs` to include `"double"` in the list of accepted value types, keeping source comments accurate and consistent with the implemented enum.

## Acceptance Criteria

- The doc comment on the `value_type` field of `ArgConfig` now correctly reads: `/// Options: "string" (default), "int", "bool", "double"` (line 185 in src/config.rs)
- No other code or logic in `config.rs` was altered by this change; only the documentation comment was updated

## Test Results

All tests pass:
- 156 unit tests (Rust)
- 16 main.rs tests
- 62 integration tests

## Notes

- Squash-merge per repository convention
- Closes #34

Generated with Claude Code