### PR TITLE
Integration tests for double value type

### DIFF
--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -817,6 +817,36 @@ else
     fail "double invalid" "Should produce error for 'abc'" "$ERROR_OUTPUT"
 fi
 
+# Test: value_type: double with zero
+run_test
+unset SHCLAP_VALUE 2>/dev/null || true
+source "$("$SHCLAP" parse --config '{"schema_version":2,"name":"test","args":[{"name":"value","long":"value","type":"option","value_type":"double"}]}' -- --value 0)"
+if [[ "${SHCLAP_VALUE:-}" == "0" ]]; then
+    pass "value_type: double accepts zero (0)"
+else
+    fail "double zero" "SHCLAP_VALUE=0" "SHCLAP_VALUE=${SHCLAP_VALUE:-unset}"
+fi
+
+# Test: value_type: double with scientific notation
+run_test
+unset SHCLAP_VALUE 2>/dev/null || true
+source "$("$SHCLAP" parse --config '{"schema_version":2,"name":"test","args":[{"name":"value","long":"value","type":"option","value_type":"double"}]}' -- --value 1e10)"
+if [[ "${SHCLAP_VALUE:-}" == "10000000000" ]]; then
+    pass "value_type: double accepts scientific notation (1e10) and produces 10000000000"
+else
+    fail "double scientific notation" "SHCLAP_VALUE=10000000000" "SHCLAP_VALUE=${SHCLAP_VALUE:-unset}"
+fi
+
+# Test: double-typed positional argument with value 3.14
+run_test
+unset SHCLAP_THRESHOLD 2>/dev/null || true
+source "$("$SHCLAP" parse --config '{"schema_version":2,"name":"test","args":[{"name":"threshold","type":"positional","value_type":"double"}]}' -- 3.14)"
+if [[ "${SHCLAP_THRESHOLD:-}" == "3.14" ]]; then
+    pass "value_type: double accepts double-typed positional argument (3.14)"
+else
+    fail "double positional" "SHCLAP_THRESHOLD=3.14" "SHCLAP_THRESHOLD=${SHCLAP_THRESHOLD:-unset}"
+fi
+
 
 section "19. Man Page Documentation"
 


### PR DESCRIPTION
## Summary

This PR adds three missing test cases to the integration test suite for the `double` value type:

- **Zero value handling**: Verifies that zero (0) is correctly accepted and produces `SHCLAP_VALUE=0`
- **Scientific notation**: Verifies that scientific notation (1e10) is properly accepted and normalized to 10000000000
- **Positional double arguments**: Verifies that double-typed positional arguments are parsed correctly and produce the expected output

These tests complete the acceptance criteria for issue #35 by ensuring all six required test scenarios for double value type validation are present in section 18 of the integration test suite.

## Test plan

- All 65 integration tests pass (including the 3 new double value type tests)
- The new tests cover all acceptance criteria specified in issue #35
- No changes to production code required; only test additions

Closes #35

Please squash-merge this PR per repository convention.

Generated with Claude Code